### PR TITLE
Set trailing comma to all

### DIFF
--- a/index.json
+++ b/index.json
@@ -10,6 +10,6 @@
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "useTabs": false
 }


### PR DESCRIPTION
In the airbnb eslint config, trailing commas are required everywhere, including in functions.
https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L41-L48