### PR TITLE
remove wrong configuration for bracket spacing

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
   "arrowParens": "avoid",
-  "bracketSpacing": false,
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
   "printWidth": 100,


### PR DESCRIPTION
In the Airbnb ESLint config, there is an array bracket spacing, but the `bracketSpacing` is related to imports, etc.

Prettier definition for bracket spacing:
https://prettier.io/docs/en/options.html#bracket-spacing

Airbnb config:
https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L14

Useful links:
https://github.com/prettier/prettier-vscode/issues/259
https://github.com/prettier/prettier/issues/296
https://eslint.org/docs/rules/array-bracket-spacing

